### PR TITLE
Flatpak docs

### DIFF
--- a/different-player.md
+++ b/different-player.md
@@ -50,6 +50,16 @@ If you are using e.g. [Clapper](https://flathub.org/apps/details/com.github.rafo
 ```
 PLAYER="flatpak-spawn --host flatpak run com.github.rafostar.Clapper"
 ```
+Depending on how you have installed the flatpak (user or system-wide):
+
+```
+flatpak --user override de.schmidhuberj.tubefeeder --env=PLAYER="flatpak-spawn --host flatpak run com.github.rafostar.Clapper"
+```
+or
+
+```
+sudo flatpak override de.schmidhuberj.tubefeeder --env=PLAYER="flatpak-spawn --host flatpak run com.github.rafostar.Clapper"
+```
 
 ## Notice
 

--- a/different-player.md
+++ b/different-player.md
@@ -21,7 +21,7 @@ Depending on how you have installed the flatpak (user or system-wide) you will h
 
 ```
 flatpak --user override de.schmidhuberj.tubefeeder --talk-name=org.freedesktop.Flatpak
-sudo override de.schmidhuberj.tubefeeder --talk-name=org.freedesktop.Flatpak
+sudo flatpak  override de.schmidhuberj.tubefeeder --talk-name=org.freedesktop.Flatpak
 ```
 
 You can check that the command worked by using


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GNU FDL 1.3 or later compatible license and the CC-BY-SA-4.0 license. Also I agree to release it here under the terms of the GNU FDL 1.3 or later and the CC-BY-SA-4.0 license.
- [x] I confirm that I have put copyright information in the new or edited files if wanted.

# Description

* Adds the  missing `flatpak` command after the `sudo` in the permission change example.
* Completes the environment variable setting example, with full `flatpak` command line.

# Linked Issue

There are no pre-existing issues reported for these.
